### PR TITLE
feat: conectar manage-appointment, new-control y perfil al API real

### DIFF
--- a/.claude/CHANGES.md
+++ b/.claude/CHANGES.md
@@ -3,11 +3,17 @@
 ## 🎯 SESIÓN ACTIVA — retomar aquí
 
 **Branch activo:** `fix/p0-1-appointment-times-patient-name`  
-**Etapa actual:** Completada — 3 bugs corregidos, pendiente PR.  
-**Próximo paso:** Crear PR de este branch y decidir qué sigue (P1-1 manage appointment o P0-6 WhatsApp phone).
+**Etapa actual:** Completada — P0-6, P1-1/2/6, P1-7, P1-9, P1-12, P1-13 resueltos en ambos repos.  
+**Próximo paso:** Aplicar migración SQL en Neon (`add_followup_to_medical_control`), luego crear PRs y planificar AppointmentTypes (P1-3, bloqueante principal restante).
 
 **Cola de esta etapa:**
 1. ✅ P0-1 — corregidos los 3 bugs de display de citas
+2. ✅ P0-6 — phone incluido en `GET /appointments/patient/:uuid` (API)
+3. ✅ P1-1/P1-2/P1-6 — Manage appointment conectado a API real (GET + PATCH)
+4. ✅ P1-7 — New control form conectado a `POST /medical-controls`; textareas vinculados al estado
+5. ✅ P1-9 — followUp persiste en columna `followUp Json?` de MedicalControl (migración pendiente de aplicar)
+6. ✅ P1-12 — `DELETE /appointments/:uuid` habilitado (use case creado + controlador + módulo)
+7. ✅ P1-13 — Perfil pre-llena nombre/email/rol desde `GET /auth/me`
 
 **Cambios de esta etapa:**
 
@@ -18,6 +24,23 @@
 | `src/components/containers/appointment/appointment-list/appointment-list-container.tsx` | Site | `loading` → `isLoading` |
 | `src/components/containers/appointment/add-appointment/use-add-appointment.ts` | Site | `date` ahora es medianoche UTC; `loading` → `isLoading` |
 | `src/components/containers/appointment/add-appointment/add-appointment.tsx` | Site | `loading` → `isLoading` |
+| `packages/medical-records/src/domain/use-cases/appointments/delete-appointment.use-case.ts` | API | Nuevo use case creado |
+| `packages/medical-records/src/app/controllers/appointments.controllers.ts` | API | DELETE habilitado; `DeleteAppointmentUseCase` inyectado |
+| `packages/medical-records/src/app/medical-records.module.ts` | API | `DeleteAppointmentUseCase` registrado |
+| `packages/medical-records/src/domain/use-cases/appointments/find-byPatient-appointment.use-case.ts` | API | Retorna `phone` y `email` del paciente |
+| `packages/medical-records/src/domain/entities/medical-control.entity.ts` | API | Agrega campo `followUp` opcional |
+| `packages/medical-records/src/infrastructure/adapters/controlRepository/medical-control.storage.ts` | API | Persiste y mapea `followUp` |
+| `packages/medical-records/src/domain/use-cases/medical-control/create-medical-control.use-case.ts` | API | Pasa `followUp` al storage |
+| `packages/medical-records/prisma/schema.prisma` | API | `MedicalControl` + columna `followUp Json?` |
+| `packages/medical-records/prisma/migrations/20260627000000_add_followup_to_medical_control/migration.sql` | API | Migración SQL (aplicar con `prisma migrate deploy`) |
+| `src/shared/api/querys/get-appointment-query.ts` | Site | Nueva query `GET /appointments/:uuid` |
+| `src/shared/api/mutations/appointments/update-appointment-mutation.ts` | Site | Nueva mutation `PATCH /appointments/:uuid` |
+| `src/components/containers/appointment/manage-appointment/use-manage-appointment.tsx` | Site | Conectado a API real; handleNoAnswer y handleConfirm con PATCH |
+| `src/components/containers/appointment/manage-appointment/manage-appointment.tsx` | Site | Skeleton loading; botones disabled durante isPending |
+| `src/components/containers/controls/new-control/use-new-control.ts` | Site | Conectado a mutation; campos de form con estado real |
+| `src/components/containers/controls/new-control/new-control-container.tsx` | Site | Textareas vinculados; botón con isPending |
+| `src/pages/controls/[id]/index.tsx` | Site | Usa `NewControlContainer` (v2) en lugar de v1 |
+| `src/pages/profile/index.tsx` | Site | Pre-llena nombre/email/rol desde `useSession()` |
 
 **Estándares activos (ver `.claude/PATTERNS.md` reglas 7-12):**
 - Sin abreviaciones en variables
@@ -99,9 +122,9 @@
 
 | Archivo | Problema |
 |---------|----------|
-| `use-new-control.ts` | `handleSave` → solo `console.log` |
+| ~~`use-new-control.ts`~~ | ✅ Conectado a mutation; textareas vinculados |
 | `use-appointment-type-form.tsx` | `handleSubmit` → `console.log` + setTimeout |
-| `use-manage-appointment.tsx` | `handleConfirm`/`handleNoAnswer` → no llaman API |
+| ~~`use-manage-appointment.tsx`~~ | ✅ handleConfirm/handleNoAnswer con PATCH real |
 | `users/edit/[id]/index.tsx` | `handleSubmit` → `console.log` + redirect |
 | `use-user-form.ts` | TODO en comentario: cambiar alerta por `showSuccess` |
 | `user-list-container.tsx:124` | `onClick: (row) => console.log('Eliminar:', row.uuid)` — delete no implementado |

--- a/.claude/PENDING.md
+++ b/.claude/PENDING.md
@@ -14,7 +14,7 @@
 | ~~P0-3~~ | ~~**Bug: "Tipos de Citas" en sidebar lleva a 404**~~ | ~~XS~~ | ~~Site~~ | ✅ Resuelto en `fix/p0-sidebar-routing-auth-guards-query-params` |
 | ~~P0-4~~ | ~~**Seguridad: `report-template/create.tsx` sin auth guard**~~ | ~~XS~~ | ~~Site~~ | ✅ Resuelto en `fix/p0-sidebar-routing-auth-guards-query-params` |
 | ~~P0-5~~ | ~~**Seguridad: `users/[id]/index.tsx` sin auth guard**~~ | ~~XS~~ | ~~Site~~ | ✅ Resuelto en `fix/p0-sidebar-routing-auth-guards-query-params` |
-| P0-6 | **Bug: WhatsApp envía mensajes al número `88165808` en vez del paciente** | S | Site + API | `GET /appointments/patient/:uuid` solo retorna `{ uuid, name }` sin `phone`. Site usa número hardcodeado como fallback. Requiere que el API incluya `phone` en esa respuesta. |
+| ~~P0-6~~ | ~~**Bug: WhatsApp envía mensajes al número `88165808` en vez del paciente**~~ | ~~S~~ | ~~Site + API~~ | ✅ API ahora retorna `phone` y `email` del paciente en `GET /appointments/patient/:uuid`. |
 | P0-7 | **Bug: form de nueva cita envía UUID falso `8e3677b3-...` como `typeUUID`** | — | Site | No tiene fix posible hasta que existan los endpoints de `AppointmentType` en el API. Documentado para no olvidar. Ver P1-3. |
 
 ---
@@ -25,20 +25,20 @@
 
 | # | Tarea | Esfuerzo | Repo | Notas |
 |---|-------|----------|------|-------|
-| P1-1 | **Manage appointment: cargar datos reales + confirmar/reagendar** | M | Site | Conectar `GET /appointments/:uuid` y `PATCH /appointments/:uuid`. Endpoints ya existen. Solo falta conexión en `use-manage-appointment.tsx`. |
-| P1-2 | **Flujo post-control: cita tentativa → llamada → confirmada/pendiente** | M | Site | El flujo ya está diseñado en `use-manage-appointment.tsx` (handleNoAnswer, handleConfirm) pero sin API real. Depende de P1-1. |
+| ~~P1-1~~ | ~~**Manage appointment: cargar datos reales + confirmar/reagendar**~~ | ~~M~~ | ~~Site~~ | ✅ Conectado a `GET /appointments/:uuid` y `PATCH /appointments/:uuid`. |
+| ~~P1-2~~ | ~~**Flujo post-control: cita tentativa → llamada → confirmada/pendiente**~~ | ~~M~~ | ~~Site~~ | ✅ handleNoAnswer y handleConfirm conectados al PATCH real. |
 | P1-3 | **AppointmentTypes CRUD: `GET/POST /appointment-types`** | L | API → Site | Tabla en DB ya existe. Implementar endpoints en API, luego conectar lista + form en site + selector en nueva cita. Desbloquea P0-7. |
 | P1-4 | **Cambiar estado de citas en lote / filtrar por estado** | S | Site | El filtro por estado ya existe en la UI (`statusFilter`). Falta: acción de cambio masivo de estado. Puede ser solo front si se hace cita por cita. |
 | P1-5 | **Registro de intentos de llamada en cita** | M | API + Site | Al hacer "No contestó" → guardar en `notes` con timestamp + contador. API: `PATCH /appointments/:uuid` ya acepta `notes`. Solo es convención de formato. |
-| P1-6 | **Cambio automático de mes si no contesta** | S | Site | Lógica en `handleNoAnswer`: sumar 1 mes + status PENDING. Ya hay código esqueleto, solo falta conectar al PATCH real. Depende de P1-1. |
+| ~~P1-6~~ | ~~**Cambio automático de mes si no contesta**~~ | ~~S~~ | ~~Site~~ | ✅ Implementado en `handleNoAnswer`: suma 1 mes + PENDING + nota de sistema + PATCH real. |
 
 ### Controles médicos
 
 | # | Tarea | Esfuerzo | Repo | Notas |
 |---|-------|----------|------|-------|
-| P1-7 | **Conectar form de nuevo control (v2) al API** | M | Site | `use-new-control.ts handleSave` → solo `console.log`. Mutation `medical-control-mutation.ts` ya existe pero no está importada. Los textareas tampoco tienen `value`/`onChange` — hay que vincular estado del form. |
+| ~~P1-7~~ | ~~**Conectar form de nuevo control (v2) al API**~~ | ~~M~~ | ~~Site~~ | ✅ `handleSave` conectado a mutation; todos los textareas vinculados; página usa v2. |
 | P1-8 | **Ver última audiometría en detalle de paciente** | S | Site | Usar `GET /medical-controls/patient/:uuid` (existe) + filtrar el más reciente con `speciality = AUDIOLOGY`. Mostrar datos del audiograma. |
-| P1-9 | **`followUp`: persistir en API** | XS | API | Solo descomentar el bloque de storage en el controlador de `POST /medical-controls`. El site ya lo envía. |
+| ~~P1-9~~ | ~~**`followUp`: persistir en API**~~ | ~~XS~~ | ~~API~~ | ✅ Columna `followUp Json?` en schema + migración SQL creada. Storage y use case actualizados. Aplicar migración con `prisma migrate deploy`. |
 
 ### Pacientes
 
@@ -46,13 +46,13 @@
 |---|-------|----------|------|-------|
 | P1-10 | **Verificar y corregir form de creación de paciente** | S | Site | El form tiene campos `name`, `id`, `nationality`, `employmentArea`. API espera `firstName`, `lastName`, `birthDate`, `address`. Hay mismatch probable — verificar `use-patient-form.ts` y el payload real que se envía. |
 | P1-11 | **Vista detalle de paciente completa** | M | Site | Completar `patient-detail-container.tsx`: mostrar datos reales, última visita, último diagnóstico (de `GET /medical-controls/patient/:uuid`). Hoy tiene datos hardcodeados en patient summary. |
-| P1-12 | **`DELETE /appointments/:uuid` — descomentar en API** | XS | API | `DeleteAppointmentUseCase` ya existe importado. Solo descomentar la entrada en el constructor del controlador. Habilita cancelar citas. |
+| ~~P1-12~~ | ~~**`DELETE /appointments/:uuid` — descomentar en API**~~ | ~~XS~~ | ~~API~~ | ✅ Use case creado, controlador y módulo actualizados. |
 
 ### Usuarios y perfil
 
 | # | Tarea | Esfuerzo | Repo | Notas |
 |---|-------|----------|------|-------|
-| P1-13 | **Perfil del médico: cargar datos reales** | S | Site | `GET /auth/me` ya existe y retorna datos del usuario. Conectar al form de perfil para pre-llenar. El guardado espera `PATCH /users/:uuid`. |
+| ~~P1-13~~ | ~~**Perfil del médico: cargar datos reales**~~ | ~~S~~ | ~~Site~~ | ✅ `useSession()` pre-llena nombre, email y rol. Guardado sigue pendiente hasta P1-14. |
 | P1-14 | **`PATCH /users/:uuid` — nuevo endpoint** | M | API → Site | Permite que el médico edite sus datos desde el perfil. Luego conectar form de perfil y user edit page. |
 
 ---

--- a/src/components/containers/appointment/manage-appointment/manage-appointment.tsx
+++ b/src/components/containers/appointment/manage-appointment/manage-appointment.tsx
@@ -5,7 +5,9 @@ import { Button, ButtonVariant } from "@/components/common/button/button";
 import { useManageAppointment } from './use-manage-appointment';
 
 export const ManageAppointmentContainer: React.FC<{ id: string }> = ({ id }) => {
-    const { formData, setFormData, loading, handleNoAnswer, handleConfirm, navigation } = useManageAppointment(id);
+    const { formData, setFormData, isLoading, isPending, handleNoAnswer, handleConfirm, navigation } = useManageAppointment(id);
+
+    if (isLoading) return <div className="max-w-3xl mx-auto py-6 animate-pulse h-96 bg-slate-100 rounded-[40px]" />;
 
     return (
         <div className="max-w-3xl mx-auto py-6">
@@ -27,6 +29,7 @@ export const ManageAppointmentContainer: React.FC<{ id: string }> = ({ id }) => 
                             variant={ButtonVariant.CANCEL}
                             className="bg-white text-red-500 border-red-100 gap-2"
                             onClick={handleNoAnswer}
+                            disabled={isPending}
                         >
                             <PhoneOff size={16} /> No contestó
                         </Button>
@@ -34,6 +37,7 @@ export const ManageAppointmentContainer: React.FC<{ id: string }> = ({ id }) => 
                             variant={ButtonVariant.PRIMARY}
                             className="bg-green-600 hover:bg-green-700 gap-2"
                             onClick={handleConfirm}
+                            disabled={isPending}
                         >
                             <CheckCircle2 size={16} /> Confirmar Cita
                         </Button>

--- a/src/components/containers/appointment/manage-appointment/use-manage-appointment.tsx
+++ b/src/components/containers/appointment/manage-appointment/use-manage-appointment.tsx
@@ -3,13 +3,18 @@ import { addMonths, format } from 'date-fns';
 import { useNavigation } from '@/hooks/use-navigation';
 import { toast } from 'sonner';
 import { AppointmentStatus } from '@/types/appointments/appointment';
+import { useAppointmentQuery } from '@/shared/api/querys/get-appointment-query';
+import { useUpdateAppointmentMutation } from '@/shared/api/mutations/appointments/update-appointment-mutation';
+import { useQueryClient } from '@tanstack/react-query';
+import { FETCH_APPOINTMENTS_KEY } from '@/shared/api/querys/appointments-query';
+import { FETCH_APPOINTMENT_KEY } from '@/shared/api/querys/get-appointment-query';
 
 export const useManageAppointment = (appointmentId: string) => {
     const navigation = useNavigation();
-    const [loading, setLoading] = useState(false);
+    const queryClient = useQueryClient();
 
-    // Aquí deberías traer los datos de la cita actual con un query
-    // const { data: appointment } = useAppointmentQuery(appointmentId);
+    const { data: appointment, isLoading } = useAppointmentQuery(appointmentId);
+    const { executeUpdateAppointment, isPending, error } = useUpdateAppointmentMutation();
 
     const [formData, setFormData] = useState({
         date: '',
@@ -18,35 +23,78 @@ export const useManageAppointment = (appointmentId: string) => {
         status: ''
     });
 
-    const handleNoAnswer = async () => {
-        setLoading(true);
-        try {
-            // Lógica: Sumar 1 mes y poner en PENDING
-            const nextMonth = addMonths(new Date(formData.date), 1);
-            const payload = {
-                date: nextMonth.toISOString(),
-                status: AppointmentStatus.PENDING,
-                notes: `${formData.notes}\n[SISTEMA]: Intento de llamada fallido. Se reprograma automáticamente.`
-            };
-            // executeUpdate(payload);
-            toast.info('Se reprogramó para el siguiente mes');
-            navigation.appointments.list();
-        } finally {
-            setLoading(false);
+    useEffect(() => {
+        if (appointment) {
+            setFormData({
+                date: appointment.schedule?.date
+                    ? format(new Date(appointment.schedule.date), 'yyyy-MM-dd')
+                    : '',
+                startTime: appointment.schedule?.startTime
+                    ? format(new Date(appointment.schedule.startTime), 'HH:mm')
+                    : '',
+                notes: appointment.notes ?? '',
+                status: appointment.status,
+            });
         }
+    }, [appointment]);
+
+    useEffect(() => {
+        if (error) toast.error('Error al actualizar la cita');
+    }, [error]);
+
+    const invalidateAppointments = () => {
+        queryClient.invalidateQueries({ queryKey: [FETCH_APPOINTMENTS_KEY] });
+        queryClient.invalidateQueries({ queryKey: [FETCH_APPOINTMENT_KEY, appointmentId] });
     };
 
-    const handleConfirm = async () => {
-        setLoading(true);
-        // Cambia a CONFIRMED y guarda
-        toast.success('Cita confirmada exitosamente');
-        navigation.appointments.list();
+    const handleNoAnswer = () => {
+        if (!formData.date) {
+            toast.error('La cita no tiene fecha válida para reprogramar');
+            return;
+        }
+        const nextMonth = addMonths(new Date(formData.date), 1);
+        const callNote = `[${format(new Date(), 'dd/MM/yyyy HH:mm')}]: Intento de llamada fallido. Se reprograma automáticamente.`;
+
+        executeUpdateAppointment(
+            {
+                uuid: appointmentId,
+                date: nextMonth.toISOString(),
+                status: AppointmentStatus.PENDING,
+                notes: formData.notes ? `${formData.notes}\n${callNote}` : callNote,
+            },
+            {
+                onSuccess: () => {
+                    invalidateAppointments();
+                    toast.info('Se reprogramó para el siguiente mes');
+                    navigation.appointments.list();
+                },
+            }
+        );
+    };
+
+    const handleConfirm = () => {
+        executeUpdateAppointment(
+            {
+                uuid: appointmentId,
+                status: AppointmentStatus.CONFIRMED,
+                notes: formData.notes,
+            },
+            {
+                onSuccess: () => {
+                    invalidateAppointments();
+                    toast.success('Cita confirmada exitosamente');
+                    navigation.appointments.list();
+                },
+            }
+        );
     };
 
     return {
         formData,
         setFormData,
-        loading,
+        isLoading,
+        isPending,
+        appointment,
         handleNoAnswer,
         handleConfirm,
         navigation

--- a/src/components/containers/controls/new-control/new-control-container.tsx
+++ b/src/components/containers/controls/new-control/new-control-container.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 export const NewControlContainer: React.FC<Props> = ({ patientId }) => {
-    const { states, setters, methods } = useNewControl();
-    const { showHistory, showAudiogram, isFollowUpModalOpen, formData } = states;
+    const { states, setters, methods } = useNewControl(patientId);
+    const { showHistory, showAudiogram, isFollowUpModalOpen, formData, isPending } = states;
 
     // Componente Reutilizable de Seguimiento (Original)
     const FollowUpFields = () => (
@@ -116,12 +116,27 @@ export const NewControlContainer: React.FC<Props> = ({ patientId }) => {
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 {formData.speciality === Speciality.AUDIOLOGY ? (
                                     <>
-                                        <textarea className="w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[110px] outline-none focus:bg-white focus:border-red-200" placeholder="Otoscopia Oído Derecho..." />
-                                        <textarea className="w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[110px] outline-none focus:bg-white focus:border-blue-200" placeholder="Otoscopia Oído Izquierdo..." />
+                                        <textarea
+                                            className="w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[110px] outline-none focus:bg-white focus:border-red-200"
+                                            placeholder="Otoscopia Oído Derecho..."
+                                            value={formData.otoscopyRight}
+                                            onChange={(e) => setters.setFormData({ ...formData, otoscopyRight: e.target.value })}
+                                        />
+                                        <textarea
+                                            className="w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[110px] outline-none focus:bg-white focus:border-blue-200"
+                                            placeholder="Otoscopia Oído Izquierdo..."
+                                            value={formData.otoscopyLeft}
+                                            onChange={(e) => setters.setFormData({ ...formData, otoscopyLeft: e.target.value })}
+                                        />
                                         {showAudiogram && <div className="col-span-2 pt-2 animate-in slide-in-from-top-4"><AudiometryCapture /></div>}
                                     </>
                                 ) : (
-                                    <textarea className="col-span-2 w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[130px] outline-none focus:bg-white focus:border-blue-200" placeholder={`Hallazgos clínicos de ${formData.speciality}...`} />
+                                    <textarea
+                                            className="col-span-2 w-full p-5 rounded-2xl border border-slate-100 bg-slate-50/30 text-sm min-h-[130px] outline-none focus:bg-white focus:border-blue-200"
+                                            placeholder={`Hallazgos clínicos de ${formData.speciality}...`}
+                                            value={formData.generalFindings}
+                                            onChange={(e) => setters.setFormData({ ...formData, generalFindings: e.target.value })}
+                                        />
                                 )}
                             </div>
                         </section>
@@ -132,7 +147,12 @@ export const NewControlContainer: React.FC<Props> = ({ patientId }) => {
                                 <StickyNote size={16} />
                                 <Typography variant={TypographyVariant.CAPTION} className="font-bold uppercase tracking-wider">Diagnóstico y Observaciones</Typography>
                             </div>
-                            <textarea className="w-full p-6 rounded-[2rem] border border-slate-100 bg-slate-50/30 text-sm min-h-[150px] outline-none focus:bg-white focus:ring-4 focus:ring-slate-50 transition-all" placeholder="Escriba el plan de tratamiento o conclusiones..." />
+                            <textarea
+                                className="w-full p-6 rounded-[2rem] border border-slate-100 bg-slate-50/30 text-sm min-h-[150px] outline-none focus:bg-white focus:ring-4 focus:ring-slate-50 transition-all"
+                                placeholder="Escriba el plan de tratamiento o conclusiones..."
+                                value={formData.diagnosis}
+                                onChange={(e) => setters.setFormData({ ...formData, diagnosis: e.target.value })}
+                            />
                         </section>
 
                         {/* SEGUIMIENTO EN PANTALLA */}
@@ -146,8 +166,8 @@ export const NewControlContainer: React.FC<Props> = ({ patientId }) => {
 
                         <div className="flex justify-end gap-3 pt-6 border-t border-slate-50">
                             <Button variant={ButtonVariant.CANCEL} text="Cancelar" />
-                            <Button onClick={methods.handleSave} variant={ButtonVariant.PRIMARY} className="!h-12 !px-10 !rounded-xl shadow-lg shadow-blue-200">
-                                <Save size={18} /> Guardar Consulta
+                            <Button onClick={methods.handleSave} variant={ButtonVariant.PRIMARY} className="!h-12 !px-10 !rounded-xl shadow-lg shadow-blue-200" disabled={isPending}>
+                                <Save size={18} /> {isPending ? 'Guardando...' : 'Guardar Consulta'}
                             </Button>
                         </div>
                     </div>

--- a/src/components/containers/controls/new-control/use-new-control.ts
+++ b/src/components/containers/controls/new-control/use-new-control.ts
@@ -1,28 +1,37 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { MedicalSpeciality } from '@/types/medical-controls/medical-control.types';
+import { useCreateMedicalControlMutation } from '@/shared/api/mutations/medical-control-mutation/medical-control-mutation';
+import { useNavigation } from '@/hooks/use-navigation';
 
-export enum Speciality {
-  AUDIOLOGY = 'Audiología',
-  DENTAL = 'Odontología',
-  DERMA = 'Dermatología',
-  GENERAL = 'Medicina General',
-}
+export const useNewControl = (patientId: string) => {
+  const navigation = useNavigation();
+  const { executeCreateControl, isPending, isSuccess, error } = useCreateMedicalControlMutation();
 
-export const useNewControl = () => {
   const [showHistory, setShowHistory] = useState(true);
   const [showAudiogram, setShowAudiogram] = useState(false);
   const [isFollowUpModalOpen, setIsFollowUpModalOpen] = useState(false);
 
   const [formData, setFormData] = useState({
-    speciality: Speciality.AUDIOLOGY,
+    speciality: MedicalSpeciality.AUDIOLOGY,
+    otoscopyRight: '',
+    otoscopyLeft: '',
+    generalFindings: '',
+    diagnosis: '',
     nextMaintenanceDate: '',
     nextControlNotes: '',
-    comments: '',
-    findings: {
-      rightEar: '',
-      leftEar: '',
-      general: '',
-    },
   });
+
+  useEffect(() => {
+    if (isSuccess) {
+      toast.success('Control médico guardado exitosamente');
+      navigation.patients.detail(patientId);
+    }
+  }, [isSuccess]);
+
+  useEffect(() => {
+    if (error) toast.error('Error al guardar el control médico');
+  }, [error]);
 
   const setQuickDate = (days: number) => {
     const date = new Date();
@@ -30,12 +39,45 @@ export const useNewControl = () => {
     setFormData({ ...formData, nextMaintenanceDate: date.toISOString().split('T')[0] });
   };
 
-  const handleSave = async () => {
-    console.log('Guardando...', formData);
+  const handleSave = () => {
+    if (!formData.diagnosis.trim()) {
+      toast.error('El diagnóstico es requerido');
+      return;
+    }
+
+    const findings =
+      formData.speciality === MedicalSpeciality.AUDIOLOGY
+        ? {
+            otoscopyRight: formData.otoscopyRight,
+            otoscopyLeft: formData.otoscopyLeft,
+            cleaningPerformed: false,
+            usesAuxiliaries: false,
+            tinnitus: false,
+          }
+        : { generalFindings: formData.generalFindings };
+
+    const hasFollowUp = !!formData.nextMaintenanceDate;
+
+    executeCreateControl({
+      header: {
+        patientUUID: patientId,
+        speciality: formData.speciality,
+        schemaVersion: 1,
+      },
+      clinicalData: {
+        findings,
+        diagnosis: formData.diagnosis,
+      },
+      followUp: {
+        hasFollowUp,
+        tentativeDate: hasFollowUp ? new Date(formData.nextMaintenanceDate).toISOString() : null,
+        notes: formData.nextControlNotes || undefined,
+      },
+    });
   };
 
   return {
-    states: { showHistory, showAudiogram, isFollowUpModalOpen, formData },
+    states: { showHistory, showAudiogram, isFollowUpModalOpen, formData, isPending },
     setters: { setShowHistory, setShowAudiogram, setIsFollowUpModalOpen, setFormData },
     methods: { setQuickDate, handleSave },
   };

--- a/src/pages/controls/[id]/index.tsx
+++ b/src/pages/controls/[id]/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { DashboardLayout } from '@/components/common/layout/dashboard-layout';
 import { BoxedLayoutStyle } from '@/components/common/layout/boxed-container/boxed-container';
 import { authorizeServerSidePage } from '@/hocs/auth';
-import { NewControlContainer } from '@/components/containers/controls/new-control-v1/new-control';
+import { NewControlContainer } from '@/components/containers/controls/new-control/new-control-container';
 import Head from 'next/head';
 
 const NewControlPage = () => {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -11,6 +11,7 @@ import { DashboardLayout } from '@/components/common/layout/dashboard-layout';
 import { BoxedLayoutStyle } from '@/components/common/layout/boxed-container/boxed-container';
 import { Typography, TypographyVariant } from '@/components/common/typography/typography';
 import { UserRole } from '@/types/auth/auth';
+import { useSession } from '@/hooks/use-session';
 
 // --- COMPONENTES ATÓMICOS REUTILIZABLES ---
 
@@ -33,6 +34,7 @@ const inputStyles = "w-full pl-12 pr-5 py-3.5 bg-white border border-slate-200 r
 
 const ProfileSettingsPage: React.FC = () => {
     const { t } = useTranslation();
+    const { user, isLoading: isSessionLoading } = useSession();
     const [activeTab, setActiveTab] = useState<'general' | 'medical'>('general');
 
     // Estados funcionales para archivos
@@ -104,11 +106,22 @@ const ProfileSettingsPage: React.FC = () => {
                                         {/* Formulario Unificado de Usuario */}
                                         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
                                             <FormField label={t('users.create.form.fullName')} icon={User}>
-                                                <input className={inputStyles} placeholder={t('users.create.form.fullNamePlaceholder')} />
+                                                <input
+                                                    className={inputStyles}
+                                                    placeholder={isSessionLoading ? 'Cargando...' : t('users.create.form.fullNamePlaceholder')}
+                                                    defaultValue={user?.fullName ?? ''}
+                                                    key={user?.fullName}
+                                                />
                                             </FormField>
 
                                             <FormField label={t('users.create.form.email')} icon={Mail}>
-                                                <input type="email" className={inputStyles} placeholder={t('users.create.form.emailPlaceholder')} />
+                                                <input
+                                                    type="email"
+                                                    className={inputStyles}
+                                                    placeholder={t('users.create.form.emailPlaceholder')}
+                                                    defaultValue={user?.email ?? ''}
+                                                    key={user?.email}
+                                                />
                                             </FormField>
 
                                             <FormField label={t('users.create.form.password')} icon={Lock}>
@@ -116,7 +129,7 @@ const ProfileSettingsPage: React.FC = () => {
                                             </FormField>
 
                                             <FormField label={t('users.create.form.role')} icon={ShieldCheck}>
-                                                <select className={inputStyles}>
+                                                <select className={inputStyles} defaultValue={user?.role ?? ''} key={user?.role}>
                                                     <option value={UserRole.DOCTOR}>{t('users.create.roles.DOCTOR')}</option>
                                                     <option value={UserRole.STAFF}>{t('users.create.roles.STAFF')}</option>
                                                     <option value={UserRole.ADMIN}>{t('users.create.roles.ADMIN')}</option>

--- a/src/shared/api/mutations/appointments/update-appointment-mutation.ts
+++ b/src/shared/api/mutations/appointments/update-appointment-mutation.ts
@@ -1,0 +1,37 @@
+import { ApiServiceClient } from '@/shared/api/api-service-client';
+import { env } from '@/shared/api/config';
+import { Appointment, AppointmentStatus } from '@/types/appointments/appointment';
+import { useApiMutation } from '../use-api-mutation';
+
+export type UpdateAppointmentPayload = {
+  uuid: string;
+  status?: AppointmentStatus;
+  date?: string;
+  startTime?: string;
+  endTime?: string;
+  notes?: string;
+};
+
+const APPOINTMENTS_URL = env.API.MEDICAL_RECORDS_URL;
+
+export function useUpdateAppointmentMutation() {
+  const {
+    mutate: executeUpdateAppointment,
+    isPending,
+    isSuccess,
+    error,
+    reset,
+  } = useApiMutation({
+    mutationKey: ['updateAppointment'],
+    mutationFn: ({ uuid, ...payload }: UpdateAppointmentPayload) =>
+      ApiServiceClient(APPOINTMENTS_URL).patch<Appointment>(`/appointments/${uuid}`, payload),
+  });
+
+  return {
+    executeUpdateAppointment,
+    isPending,
+    isSuccess,
+    error: !!error,
+    reset,
+  };
+}

--- a/src/shared/api/querys/get-appointment-query.ts
+++ b/src/shared/api/querys/get-appointment-query.ts
@@ -1,0 +1,22 @@
+import { ApiServiceClient } from '@/shared/api/api-service-client';
+import { env } from '@/shared/api/config';
+import { Appointment } from '@/types/appointments/appointment';
+import { useQuery } from '@tanstack/react-query';
+
+const APPOINTMENTS_URL = env.API.MEDICAL_RECORDS_URL;
+
+const AppointmentService = {
+  fetchOne: async (uuid: string): Promise<Appointment> =>
+    ApiServiceClient(APPOINTMENTS_URL).get<Appointment>(`/appointments/${uuid}`),
+};
+
+export const FETCH_APPOINTMENT_KEY = 'fetchAppointment';
+
+export function useAppointmentQuery(uuid: string) {
+  return useQuery({
+    queryKey: [FETCH_APPOINTMENT_KEY, uuid],
+    queryFn: () => AppointmentService.fetchOne(uuid),
+    enabled: !!uuid,
+    staleTime: 1000 * 60 * 5,
+  });
+}


### PR DESCRIPTION
- Manage appointment: GET /appointments/:uuid carga datos; PATCH confirma o reprograma al mes siguiente con nota de sistema (P1-1, P1-2, P1-6)
- New control (v2): form conectado a POST /medical-controls, todos los textareas vinculados al estado; página usa container v2 (P1-7)
- Perfil: pre-llena nombre, email y rol desde GET /auth/me (P1-13)
- Nuevas: get-appointment-query.ts, update-appointment-mutation.ts